### PR TITLE
Initialize the terminal as needed.

### DIFF
--- a/src/Inspector.hs
+++ b/src/Inspector.hs
@@ -47,6 +47,8 @@ import           Inspector.TestVector.Types      (Type)
 import           Inspector.TestVector.Value      (Value)
 import           Inspector.TestVector.TestVector (Entry(..), TestVector)
 
+import Basement.Terminal as Terminal (initialize)
+
 import Foundation
 import Foundation.Monad
 import Foundation.Conduit
@@ -61,6 +63,7 @@ import qualified System.Environment as S (getArgs)
 -- | handy one for test suite for cabal
 defaultTest :: GoldenT () -> IO ()
 defaultTest suites = do
+    Terminal.initialize
     args <- S.getArgs
     (opts, command) <- case getOpt Permute options args of
         (o, cmd,  []) -> return (o, cmd)


### PR DESCRIPTION
This should set the terminal to utf8 if it is not already on windows.
As such prevents errors like:
```
golden-tests.exe: <stdout>: commitBuffer: invalid argument (invalid character)
```