### PR TITLE
Fixes to build on multiple GHCs

### DIFF
--- a/src/Inspector/Builder.hs
+++ b/src/Inspector/Builder.hs
@@ -13,7 +13,6 @@ module Inspector.Builder
 import Foundation
 import Foundation.Monad
 import Foundation.Monad.State
-import Foundation.Collection (replicate)
 
 import qualified Foundation.String.Builder as Builder
 

--- a/src/Inspector/Export/Diff.hs
+++ b/src/Inspector/Export/Diff.hs
@@ -4,7 +4,6 @@ module Inspector.Export.Diff
 
 import Foundation
 import Foundation.VFS.FilePath (FilePath, filePathToString)
-import Foundation.Collection (filter)
 import Basement.Bounded (zn64)
 import qualified Basement.Terminal.ANSI as ANSI
 import Foundation.Monad

--- a/src/Inspector/Export/Markdown.hs
+++ b/src/Inspector/Export/Markdown.hs
@@ -7,7 +7,6 @@ module Inspector.Export.Markdown
     ) where
 
 import Foundation
-import Foundation.VFS.FilePath (FilePath)
 import Foundation.Collection (nonEmpty_)
 import Foundation.Monad
 import Foundation.IO (withFile, IOMode(..), hPut)

--- a/src/Inspector/Export/Rust.hs
+++ b/src/Inspector/Export/Rust.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE Rank2Types #-}
 {-# LANGUAGE FlexibleContexts #-}


### PR DESCRIPTION
Changes required to build on:

* ghc-8.8.3
* ghc-8.10.1

The following [Circle CI builds](https://app.circleci.com/pipelines/github/haskell-works/inspector/3/workflows/df91f66c-f23b-47bd-8f98-fe92b2d64783) show successful builds for:

* ghc-8.0.2
* ghc-8.2.2
* ghc-8.4.4
* ghc-8.6.5
* ghc-8.8.3
* ghc-8.10.1
